### PR TITLE
Avoid errors when SELinux is disabled

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,32 +55,34 @@ class apache (
         }
     }
 
-    selinux::boolean {
-        default:
-            before     => Class['apache::service'],
-            persistent => true,
-            ;
-        'httpd_anon_write':
-            ensure => $anon_write,
-            ;
-        'httpd_can_network_connect':
-            ensure => $network_connect,
-            ;
-        'httpd_can_network_connect_db':
-            ensure => $network_connect_db,
-            ;
-        'httpd_can_network_relay':
-            ensure => $network_relay,
-            ;
-        'httpd_can_sendmail':
-            ensure => $send_mail,
-            ;
-        'httpd_execmem':
-            ensure => $execmem,
-            ;
-        'httpd_use_nfs':
-            ensure => $use_nfs,
-            ;
+    if $facts['selinux'] {
+        selinux::boolean {
+            default:
+                before     => Class['apache::service'],
+                persistent => true,
+                ;
+            'httpd_anon_write':
+                ensure => $anon_write,
+                ;
+            'httpd_can_network_connect':
+                ensure => $network_connect,
+                ;
+            'httpd_can_network_connect_db':
+                ensure => $network_connect_db,
+                ;
+            'httpd_can_network_relay':
+                ensure => $network_relay,
+                ;
+            'httpd_can_sendmail':
+                ensure => $send_mail,
+                ;
+            'httpd_execmem':
+                ensure => $execmem,
+                ;
+            'httpd_use_nfs':
+                ensure => $use_nfs,
+                ;
+        }
     }
 
 }


### PR DESCRIPTION
selinux::boolean resources will cause errors on nodes which have SELinux disabled.  For example, the following errors are shown when compiling the puppet catalog on a host with SELinux disabled.

```
Error: /Stage[main]/Apache/Selinux::Boolean[httpd_anon_write]/Selboolean[httpd_anon_write]: Could not evaluate: Execution of '/usr/sbin/getsebool httpd_anon_write' returned 1: /usr/sbin/getsebool:  SELinux is disabled                                                                                                                   
Error: /Stage[main]/Apache/Selinux::Boolean[httpd_can_network_connect]/Selboolean[httpd_can_network_connect]: Could not evaluate: Execution of '/usr/sbin/getsebool httpd_can_network_connect' returned 1: /usr/sbin/getsebool:  SELinux is disabled                                                                                        
Error: /Stage[main]/Apache/Selinux::Boolean[httpd_can_network_connect_db]/Selboolean[httpd_can_network_connect_db]: Could not evaluate: Execution of '/usr/sbin/getsebool httpd_can_network_connect_db' returned 1: /usr/sbin/getsebool:  SELinux is disabled                                                                               
Error: /Stage[main]/Apache/Selinux::Boolean[httpd_can_network_relay]/Selboolean[httpd_can_network_relay]: Could not evaluate: Execution of '/usr/sbin/getsebool httpd_can_network_relay' returned 1: /usr/sbin/getsebool:  SELinux is disabled                                                                                              
Error: /Stage[main]/Apache/Selinux::Boolean[httpd_can_sendmail]/Selboolean[httpd_can_sendmail]: Could not evaluate: Execution of '/usr/sbin/getsebool httpd_can_sendmail' returned 1: /usr/sbin/getsebool:  SELinux is disabled                                                                                                             
Error: /Stage[main]/Apache/Selinux::Boolean[httpd_execmem]/Selboolean[httpd_execmem]: Could not evaluate: Execution of '/usr/sbin/getsebool httpd_execmem' returned 1: /usr/sbin/getsebool:  SELinux is disabled                                                                                                                            
Error: /Stage[main]/Apache/Selinux::Boolean[httpd_use_nfs]/Selboolean[httpd_use_nfs]: Could not evaluate: Execution of '/usr/sbin/getsebool httpd_use_nfs' returned 1: /usr/sbin/getsebool:  SELinux is disabled
```

This patch adds a simple check to determine if SELinux is enabled before attempting to manage selinux resources.