### PR TITLE
Fix SELinux failures on older puppet clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This module lets you manage the Apache httpd web server.
 * [apache::mod\_auth\_gssapi](#apachemod_auth_gssapi-class)
 * [apache::mod\_passenger](#apachemod_passenger-class)
 * [apache::mod\_ssl](#apachemod_ssl-class)
+* [apache::mod\_status](#apachemod_status-class)
 * [apache::mod\_wsgi](#apachemod_wsgi-class)
 * [apache::package](#apachepackage-class)
 * [apache::service](#apacheservice-class)
@@ -118,6 +119,19 @@ This class manages the Apache web server to provide HTTPS support.
 
 ##### `manage_firewall`
 If `true`, open the HTTPS port on the firewall.  Otherwise the firewall is left unaffected.  Defaults to `true`.
+
+
+#### apache::mod\_status class
+
+This class manages the Apache status module which provides reports of server activity.  By default access will
+only be allowed on the local loopback interface.
+
+##### `location`
+This parameter controls the location used to access the apache status page.  The default value will be set to `'/server-status'`.
+
+##### `allow_from`
+An array of IPs or IP ranges in CIDR format which defines the hosts allowed to access the server status page.
+The default value will be set to `['127.0.0.1', '::1']`.
 
 
 #### apache::mod\_wsgi class

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -25,6 +25,11 @@ apache::mod_ssl::manage_firewall:   true
 apache::mod_ssl::packages:
     - mod_ssl
 
+apache::mod_status::location: '/server-status'
+apache::mod_status::allow_from:
+    - '127.0.0.1'
+    - '::1'
+
 apache::mod_wsgi::packages:
     - mod_wsgi
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class apache (
         }
     }
 
-    if $facts['selinux'] {
+    if $facts['selinux'] == true {
         selinux::boolean {
             default:
                 before     => Class['apache::service'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,32 +55,34 @@ class apache (
         }
     }
 
-    selinux::boolean {
-        default:
-            before     => Class['apache::service'],
-            persistent => true,
-            ;
-        'httpd_anon_write':
-            ensure => $anon_write,
-            ;
-        'httpd_can_network_connect':
-            ensure => $network_connect,
-            ;
-        'httpd_can_network_connect_db':
-            ensure => $network_connect_db,
-            ;
-        'httpd_can_network_relay':
-            ensure => $network_relay,
-            ;
-        'httpd_can_sendmail':
-            ensure => $send_mail,
-            ;
-        'httpd_execmem':
-            ensure => $execmem,
-            ;
-        'httpd_use_nfs':
-            ensure => $use_nfs,
-            ;
+    if $facts['selinux'] {
+        selinux::boolean {
+            default:
+                before     => Class['apache::service'],
+                persistent => true,
+                ;
+            'httpd_anon_write':
+                ensure => $anon_write,
+                ;
+            'httpd_can_network_connect':
+                ensure => $network_connect,
+                ;
+            'httpd_can_network_connect_db':
+                ensure => $network_connect_db,
+                ;
+            'httpd_can_network_relay':
+                ensure => $network_relay,
+                ;
+            'httpd_can_sendmail':
+                ensure => $send_mail,
+                ;
+            'httpd_execmem':
+                ensure => $execmem,
+                ;
+            'httpd_use_nfs':
+                ensure => $use_nfs,
+                ;
+        }
     }
 
 }

--- a/manifests/mod_status.pp
+++ b/manifests/mod_status.pp
@@ -1,0 +1,38 @@
+# modules/apache/manifests/mod_status.pp
+#
+# == Class: apache::mod_status
+#
+# Configures the Apache server status page.
+#
+# === Parameters
+#
+#  [*location*]
+#  This parameter controls the location used to access the apache status page.  Default value is set to /server-status.
+#
+#  [*allow_from*]
+#  This parameter controls what IPs or IP ranges are allowed to access the apache status page.
+#
+# === Authors
+#
+#   Michael Watters <michael.watters@dart.biz>
+#
+# === Copyright
+#
+# This file is part of the doubledog-apache Puppet module.
+# Copyright 2017-2019 John Florian
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+class apache::mod_status (
+    String[1] $location,
+    Array[String] $allow_from,
+    ) {
+
+    include 'apache'
+
+    file { '/etc/httpd/conf.d/mod_status.conf':
+        content => template('apache/mod_status.conf.erb'),
+        notify  => Class['apache::service'],
+        require => Class['apache::package'],
+    }
+
+}

--- a/templates/mod_status.conf.erb
+++ b/templates/mod_status.conf.erb
@@ -1,0 +1,6 @@
+ExtendedStatus on
+
+<Location <%= @location %>>
+  SetHandler server-status
+  Require ip <%= @allow_from.join(' ') %>
+</Location>


### PR DESCRIPTION
On some nodes the if statement returns as true if the selinux
fact is *defined*, even when SELinux is disabled. This change modifies the check to ensure that
$facts['selinux'] returns as true, not that it simply exists.
