### PR TITLE
Fix SELinux failures on older puppet clients

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class apache (
         }
     }
 
-    if $facts['selinux'] {
+    if $facts['selinux'] == true {
         selinux::boolean {
             default:
                 before     => Class['apache::service'],


### PR DESCRIPTION
It looks like this change wasn't actually pulled in.