### PR TITLE
Update metadata to support puppetlabs-firewall 2.0.0 release

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
         },
         {
             "name": "puppetlabs/firewall",
-            "version_requirement": ">= 1.8.0 < 2.0.0"
+            "version_requirement": ">= 1.8.0 <= 2.0.0"
         }
     ]
 }


### PR DESCRIPTION
puppetlabs-firewall 2.0 has been released.