### PR TITLE
Change - allow puppet/selinux version 3.0.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
         },
         {
             "name": "puppet/selinux",
-            "version_requirement": ">= 1.6.0 < 2.0.0"
+            "version_requirement": ">= 1.6.0 <= 3.0.1"
         },
         {
             "name": "puppetlabs/firewall",


### PR DESCRIPTION
Updated metadata to allow use of puppet-selinux version 3.0.1.